### PR TITLE
Develop

### DIFF
--- a/src/Base.php
+++ b/src/Base.php
@@ -25,7 +25,9 @@ class Base
                 'Accept' => 'application/json',
                 'Content-Type' => 'application/json',
                 'Tus-Resumable' => '1.0.0',
-                'Upload-Creator' => auth()->id(),
+                'Upload-Creator' => 'creator-id_'. auth()->user()->first_name
+                    ?? auth()->user()->name ?? 'N/A'
+                    .auth()->id() ?? auth()->user()->uuid ?? '',
                 'Upload-Length' => '',
                 'Upload-Metadata' => '',
                 'X-Auth-Email' => $this->authEmail,

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -29,6 +29,7 @@ class Stream extends Base
                 [
                     RequestOptions::JSON => [
                         'url' => $url,
+                        'meta' => $options['meta'] ?? [],
                         'requireSignedURLs' => $options['require_signed_urls'] ?? false,
                         'scheduledDeletion' => $options['expiry'] ?? null,
                         'creator' => $options['creator'] ?? null,


### PR DESCRIPTION
- add meta param to request options
- improve default Upload-Creator header value to use either the authenticated user firstname or name along with the id or uuid, else set to 'N/A'.